### PR TITLE
Gethistory

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -14,6 +14,7 @@ Commands must be sent as valid JSONRPC 2.0 requests, ending with a `\n`.
 | [`delspendtx`](#delspendtx)                                 | Delete a stored Spend transaction                    |
 | [`broadcastspend`](#broadcastspend)                         | Finalize a stored Spend PSBT, and broadcast it       |
 | [`startrescan`](#startrescan)                               | Start rescanning the block chain from a given date   |
+| [`gethistory`](#gethistory)                                 | List of incoming and outgoing movements of funds     |
 
 # Reference
 
@@ -242,9 +243,9 @@ of inflows and outflows net of any change amount (that is technically a transact
 | Field         | Type          | Description                                                                                                             |
 | ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `blockheight` | int           | Blockheight of the event transaction                                                                                    |
-| `txid`        | string        | Hex string  of the event transaction id                                                                                 |
 | `kind`        | string        | Type of the event. Can be `receive`, `spend`                                                                            |
 | `date`        | int           | Timestamp of the event                                                                                                  |
-| `amount`      | int or `null` | Absolute amount in satoshis that is entering or exiting the wallet, `null` if the event is a `cancel` event             |
+| `amount`      | int           | Absolute amount in satoshis that is entering or exiting the wallet                                                      |
 | `miner_fee`   | int or `null` | Total of the miner fees caused by the operation, `null` if the event is a `receive` event                               |
-| `coins`       | string array  | List of outpoints of coins affected by the event excluding any change coin                                              |
+| `tx`          | string        | bitcoin transaction of the spend, `null` if the event is a `receive` event                                              |
+| `outpoint`    | string        | Hex string of the output created by this `receive` event, `null` if the event is a `spend` event                        |

--- a/doc/API.md
+++ b/doc/API.md
@@ -186,7 +186,6 @@ This command does not return anything for now.
 | Field          | Type      | Description                                          |
 | -------------- | --------- | ---------------------------------------------------- |
 
-
 ### `broadcastspend`
 
 #### Request
@@ -202,7 +201,6 @@ This command does not return anything for now.
 | Field          | Type      | Description                                          |
 | -------------- | --------- | ---------------------------------------------------- |
 
-
 ### `startrescan`
 
 #### Request
@@ -217,3 +215,36 @@ This command does not return anything for now.
 
 | Field          | Type      | Description                                          |
 | -------------- | --------- | ---------------------------------------------------- |
+
+### `gethistory`
+
+`gethistory` retrieves a paginated list of accounting events.
+
+Aiming at giving an accounting point of view, the amounts returned by this call are the total
+of inflows and outflows net of any change amount (that is technically a transaction output, but not a cash outflow).
+
+#### Request
+
+| Field         | Type         | Description                                                          |
+| ------------- | ------------ | -------------------------------------------------------------------- |
+| `start`       | int          | Timestamp of the beginning of the period to retrieve events for      |
+| `end`         | int          | Timestamp of the end of the period to retrieve events for            |
+| `limit`       | int          | Maximum number of events to retrieve                                 |
+
+#### Response
+
+| Field          | Type   | Description                                |
+| -------------- | ------ | ------------------------------------------ |
+| `events`       | array  | Array of [Event resource](#event-resource) |
+
+##### Event Resource
+
+| Field         | Type          | Description                                                                                                             |
+| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `blockheight` | int           | Blockheight of the event transaction                                                                                    |
+| `txid`        | string        | Hex string  of the event transaction id                                                                                 |
+| `kind`        | string        | Type of the event. Can be `receive`, `spend`                                                                            |
+| `date`        | int           | Timestamp of the event                                                                                                  |
+| `amount`      | int or `null` | Absolute amount in satoshis that is entering or exiting the wallet, `null` if the event is a `cancel` event             |
+| `miner_fee`   | int or `null` | Total of the miner fees caused by the operation, `null` if the event is a `receive` event                               |
+| `coins`       | string array  | List of outpoints of coins affected by the event excluding any change coin                                              |

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -88,6 +88,9 @@ pub trait BitcoinInterface: Send {
     /// Get the last block chain tip with a timestamp below this. Timestamp must be a valid block
     /// timestamp.
     fn block_before_date(&self, timestamp: u32) -> Option<BlockChainTip>;
+
+    /// Get wallet Transaction retrieves the wallet transaction.
+    fn wallet_transaction(&self, txid: &bitcoin::Txid) -> Option<bitcoin::Transaction>;
 }
 
 impl BitcoinInterface for d::BitcoinD {
@@ -309,6 +312,10 @@ impl BitcoinInterface for d::BitcoinD {
         let tip = self.chain_tip();
         self.get_block_stats(tip.hash).time
     }
+
+    fn wallet_transaction(&self, txid: &bitcoin::Txid) -> Option<bitcoin::Transaction> {
+        self.get_transaction(txid).map(|res| res.tx)
+    }
 }
 
 // FIXME: do we need to repeat the entire trait implemenation? Isn't there a nicer way?
@@ -384,6 +391,10 @@ impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>>
 
     fn tip_time(&self) -> u32 {
         self.lock().unwrap().tip_time()
+    }
+
+    fn wallet_transaction(&self, txid: &bitcoin::Txid) -> Option<bitcoin::Transaction> {
+        self.lock().unwrap().wallet_transaction(txid)
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -750,7 +750,7 @@ mod tests {
 
     #[test]
     fn getinfo() {
-        let ms = DummyMinisafe::new();
+        let ms = DummyMinisafe::new(DummyBitcoind::new(), DummyDatabase::new());
         // We can query getinfo
         ms.handle.control.get_info();
         ms.shutdown();
@@ -758,7 +758,7 @@ mod tests {
 
     #[test]
     fn getnewaddress() {
-        let ms = DummyMinisafe::new();
+        let ms = DummyMinisafe::new(DummyBitcoind::new(), DummyDatabase::new());
 
         let control = &ms.handle.control;
         // We can get an address
@@ -779,7 +779,7 @@ mod tests {
 
     #[test]
     fn create_spend() {
-        let ms = DummyMinisafe::new();
+        let ms = DummyMinisafe::new(DummyBitcoind::new(), DummyDatabase::new());
         let control = &ms.handle.control;
 
         // Arguments sanity checking
@@ -895,7 +895,7 @@ mod tests {
 
     #[test]
     fn update_spend() {
-        let ms = DummyMinisafe::new();
+        let ms = DummyMinisafe::new(DummyBitcoind::new(), DummyDatabase::new());
         let control = &ms.handle.control;
         let mut db_conn = control.db().lock().unwrap().connection();
 

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -54,3 +54,25 @@ pub fn change_index(psbt: &Psbt, db_conn: &mut Box<dyn DatabaseConnection>) -> O
 
     None
 }
+
+/// Serialize an amount option as sats
+pub fn ser_optional_amount<S: Serializer>(
+    amount: &Option<bitcoin::Amount>,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    match amount {
+        Some(amount) => s.serialize_u64(amount.to_sat()),
+        None => s.serialize_none(),
+    }
+}
+
+/// Deserialize an amount option from sats
+pub fn deser_optional_amount_from_sats<'de, D>(
+    deserializer: D,
+) -> Result<Option<bitcoin::Amount>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let a = Option::<u64>::deserialize(deserializer)?;
+    Ok(a.map(bitcoin::Amount::from_sat))
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -105,6 +105,9 @@ pub trait DatabaseConnection {
 
     /// Mark the given tip as the new best seen block. Update stored data accordingly.
     fn rollback_tip(&mut self, new_tip: &BlockChainTip);
+
+    /// Retrieved a limited list of coins that where deposited or spent between the start and end timestamps.
+    fn list_updated_coins(&mut self, start: u32, end: u32, limit: u64) -> Vec<Coin>;
 }
 
 impl DatabaseConnection for SqliteConn {
@@ -224,6 +227,13 @@ impl DatabaseConnection for SqliteConn {
 
     fn rollback_tip(&mut self, new_tip: &BlockChainTip) {
         self.rollback_tip(new_tip)
+    }
+
+    fn list_updated_coins(&mut self, start: u32, end: u32, limit: u64) -> Vec<Coin> {
+        self.db_list_updated_coins(start, end, limit)
+            .into_iter()
+            .map(Coin::from)
+            .collect()
     }
 }
 

--- a/src/jsonrpc/api.rs
+++ b/src/jsonrpc/api.rs
@@ -136,6 +136,24 @@ pub fn handle_request(control: &DaemonControl, req: Request) -> Result<Response,
                 .ok_or_else(|| Error::invalid_params("Missing 'psbt' parameter."))?;
             update_spend(control, params)?
         }
+        "gethistory" => match req.params {
+            Some(Params::Array(params)) => {
+                if params.len() != 3 {
+                    return Err(Error::invalid_params("command requires 3 parameters"));
+                }
+                if let (Some(start), Some(end), Some(limit)) = (
+                    serde_json::Value::as_u64(&params[0]),
+                    serde_json::Value::as_u64(&params[1]),
+                    serde_json::Value::as_u64(&params[2]),
+                ) {
+                    serde_json::json!(&control.gethistory(start as u32, end as u32, limit))
+                } else {
+                    return Err(Error::invalid_params("command requires 3 parameters"));
+                }
+            }
+            None => return Err(Error::invalid_params("command requires 3 parameters")),
+            _ => return Err(Error::invalid_params("invalid parameters")),
+        },
         _ => {
             return Err(Error::method_not_found());
         }

--- a/src/jsonrpc/server.rs
+++ b/src/jsonrpc/server.rs
@@ -400,7 +400,7 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn server_sanity_check() {
-        let ms = DummyMinisafe::new();
+        let ms = DummyMinisafe::new(DummyBitcoind::new(), DummyDatabase::new());
         let socket_path: path::PathBuf = [
             ms.tmp_dir.as_path(),
             path::Path::new("d"),

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -105,7 +105,7 @@ impl BitcoinInterface for DummyBitcoind {
     }
 
     fn wallet_transaction(&self, txid: &bitcoin::Txid) -> Option<bitcoin::Transaction> {
-        self.txs.get(txid).map(|tx| tx.clone())
+        self.txs.get(txid).cloned()
     }
 }
 
@@ -334,7 +334,7 @@ impl DatabaseConnection for DummyDatabase {
                 if !updated_coins.contains(coin)
                     && (coin.outpoint.txid == *txid || coin.spend_txid == Some(*txid))
                 {
-                    updated_coins.push(coin.clone());
+                    updated_coins.push(*coin);
                 }
             }
         }


### PR DESCRIPTION
A new command `gethistory` that retrieves the `<limit>` events between `<start>` and `<end>` timestamps (See doc/API.md)
I requires two new columns in the `coins` table: 
* `blocktime`: timestamp of the block containing the transaction funding the coin.
* `spent_at`: timestamp of the block containing the transaction spending the coin.