### PR TITLE
daemon: update rust-miniscript to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,8 +255,8 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniscript"
-version = "8.0.0"
-source = "git+https://github.com/darosior/rust-miniscript?branch=multipath_descriptors_on_8.0#a63d5a263a9006b4d29342012133a3bc919765ba"
+version = "9.0.0"
+source = "git+https://github.com/darosior/rust-miniscript?branch=multipath_descriptors_on_9.0#3104519501ce6ad15b36dcec759936f4d3bd3980"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ jsonrpc_server = []
 
 [dependencies]
 # For managing transactions (it re-exports the bitcoin crate)
-# TODO: don't use my fork for a real release..
-miniscript = { git = "https://github.com/darosior/rust-miniscript", branch = "multipath_descriptors_on_8.0", features = ["serde"] }
+miniscript = { version = "9.0", features = ["serde"] }
 
 # Don't reinvent the wheel
 dirs = "3.0"
@@ -57,3 +56,6 @@ libc = "0.2"
 
 # Used for PSBTs
 base64 = "0.13"
+
+[patch.crates-io]
+miniscript = { git = "https://github.com/darosior/rust-miniscript", branch = "multipath_descriptors_on_9.0" }

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -190,12 +190,13 @@ fn is_valid_desc_key(key: &descriptor::DescriptorPublicKey) -> bool {
             false
         }
         descriptor::DescriptorPublicKey::MultiXPub(ref xpub) => {
+            let der_paths = xpub.derivation_paths.paths();
             // Rust-miniscript enforces BIP389 which states that all paths must have the same len.
-            let len = xpub.derivation_paths.get(0).expect("Cannot be empty").len();
+            let len = der_paths.get(0).expect("Cannot be empty").len();
             xpub.wildcard == descriptor::Wildcard::Unhardened
-                && xpub.derivation_paths.len() == 2
-                && xpub.derivation_paths[0][len - 1] == 0.into()
-                && xpub.derivation_paths[1][len - 1] == 1.into()
+                && der_paths.len() == 2
+                && der_paths[0][len - 1] == 0.into()
+                && der_paths[1][len - 1] == 1.into()
         }
     }
 }


### PR DESCRIPTION
This also updates the multipaths descriptor patch to the review PR https://github.com/rust-bitcoin/rust-miniscript/pull/470 (rebased on 0.9)

Fixes #123.