### PR TITLE
Friendlier bitcoind startup error handling

### DIFF
--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -60,8 +60,8 @@ fn main() {
     });
 
     let daemon = DaemonHandle::start_default(config).unwrap_or_else(|e| {
-        // The panic hook will log::error
-        panic!("Starting Liana daemon: {}", e);
+        log::error!("Error starting Liana daemon: {}", e);
+        process::exit(1);
     });
     daemon
         .rpc_server()

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -245,7 +245,7 @@ impl BitcoinD {
             sendonly_client,
             watchonly_client,
             watchonly_wallet_path,
-            retries: 0,
+            retries: BITCOIND_RETRY_LIMIT,
         })
     }
 
@@ -268,12 +268,6 @@ impl BitcoinD {
         self.check_client(&self.node_client)?;
         self.check_client(&self.watchonly_client)?;
         Ok(())
-    }
-
-    /// Set how many times we'll retry a failed request. If passed None will set to default.
-    pub fn with_retry_limit(mut self, retry_limit: Option<usize>) -> Self {
-        self.retries = retry_limit.unwrap_or(BITCOIND_RETRY_LIMIT);
-        self
     }
 
     /// Wrapper to retry a request sent to bitcoind upon IO failure

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ fn setup_bitcoind(
     bitcoind.sanity_check(&config.main_descriptor, config.bitcoin_config.network)?;
     log::info!("Connection to bitcoind established and checked.");
 
-    Ok(bitcoind.with_retry_limit(None))
+    Ok(bitcoind)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
We were not properly treating warming up errors when bitcoind was starting up. Also, better to just log as error and `exit` with `1` instead of panic'ing on a daemon startup error.

See the commit messages for details.

Fixes #134 
Fixes #163