### PR TITLE
Recovery command to sweep "expired" coins

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -11,12 +11,15 @@ Commands must be sent as valid JSONRPC 2.0 requests, ending with a `\n`.
 | [`getinfo`](#getinfo)                                       | Get general information about the daemon                      |
 | [`getnewaddress`](#getnewaddress)                           | Get a new receiving address                                   |
 | [`listcoins`](#listcoins)                                   | List all wallet transaction outputs.                          |
+| [`createspend`](#createspend)                               | Create a new Spend transaction                                |
+| [`updatespend`](#updatespend)                               | Store a created Spend transaction                             |
 | [`listspendtxs`](#listspendtxs)                             | List all stored Spend transactions                            |
 | [`delspendtx`](#delspendtx)                                 | Delete a stored Spend transaction                             |
 | [`broadcastspend`](#broadcastspend)                         | Finalize a stored Spend PSBT, and broadcast it                |
 | [`startrescan`](#startrescan)                               | Start rescanning the block chain from a given date            |
 | [`listconfirmed`](#listconfirmed)                           | List of confirmed transactions of incoming and outgoing funds |
 | [`listtransactions`](#listtransactions)                     | List of transactions with the given txids                     |
+| [`createrecovery`](#createrecovery)                         | Create a recovery transaction to sweep expired coins          |
 
 # Reference
 
@@ -261,3 +264,25 @@ Confirmation time is based on the timestamp of blocks.
 | Field          | Type   | Description                                            |
 | -------------- | ------ | ------------------------------------------------------ |
 | `transactions` | array  | Array of [Transaction resource](#transaction-resource) |
+
+
+### `createrecovery`
+
+Create a transaction that sweeps all coins whose timelocked recovery path is available to a provided
+address at a provided feerate.
+
+Will error if no such coins are available or the sum of their value is not enough to cover the
+requested feerate.
+
+#### Request
+
+| Field      | Type              | Description                                                       |
+| ---------- | ----------------- | ----------------------------------------------------------------- |
+| `address`  | str               | The Bitcoin address to sweep the coins to.                        |
+| `feerate`  | integer           | Target feerate for the transaction, in satoshis per virtual byte. |
+
+#### Response
+
+| Field          | Type      | Description                                          |
+| -------------- | --------- | ---------------------------------------------------- |
+| `psbt`         | string    | PSBT of the recovery transaction, encoded as base64. |

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitcoin::{BitcoinInterface, BlockChainTip, UTxO},
-    database::{Coin, DatabaseConnection, DatabaseInterface},
+    database::{Coin, CoinType, DatabaseConnection, DatabaseInterface},
     descriptors,
 };
 
@@ -30,7 +30,7 @@ fn update_coins(
     descs: &[descriptors::InheritanceDescriptor],
     secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
 ) -> UpdatedCoins {
-    let curr_coins = db_conn.coins();
+    let curr_coins = db_conn.coins(CoinType::All);
     log::debug!("Current coins: {:?}", curr_coins);
 
     // Start by fetching newly received coins.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -39,7 +39,7 @@ const DUST_OUTPUT_SATS: u64 = 5_000;
 const MAX_FEE: u64 = bitcoin::blockdata::constants::COIN_VALUE;
 
 // Assume that paying more than 1000sat/vb in feerate is a bug.
-const MAX_FEERATE: u64 = bitcoin::blockdata::constants::COIN_VALUE;
+const MAX_FEERATE: u64 = 1_000;
 
 // Timestamp in the header of the genesis block. Used for sanity checks.
 const MAINNET_GENESIS_TIME: u32 = 1231006505;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -162,6 +162,13 @@ fn sanity_check_psbt(psbt: &Psbt) -> Result<(), CommandError> {
         return Err(CommandError::SanityCheckFailure(psbt.clone()));
     }
 
+    // Check for dust outputs
+    for txo in psbt.unsigned_tx.output.iter() {
+        if txo.value < txo.script_pubkey.dust_value().to_sat() {
+            return Err(CommandError::SanityCheckFailure(psbt.clone()));
+        }
+    }
+
     Ok(())
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,7 +6,7 @@ mod utils;
 
 use crate::{
     bitcoin::BitcoinInterface,
-    database::{Coin, DatabaseInterface},
+    database::{Coin, CoinType, DatabaseInterface},
     descriptors, DaemonControl, VERSION,
 };
 
@@ -243,7 +243,7 @@ impl DaemonControl {
     pub fn list_coins(&self) -> ListCoinsResult {
         let mut db_conn = self.db.connection();
         let coins: Vec<ListCoinsEntry> = db_conn
-            .coins()
+            .coins(CoinType::All)
             // Can't use into_values as of Rust 1.48
             .into_iter()
             .map(|(_, coin)| {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -301,8 +301,8 @@ impl DaemonControl {
         // fees, and add necessary information to the PSBT inputs.
         let mut in_value = bitcoin::Amount::from_sat(0);
         let mut sat_vb = 0;
-        let mut txins = Vec::with_capacity(destinations.len());
-        let mut psbt_ins = Vec::with_capacity(destinations.len());
+        let mut txins = Vec::with_capacity(coins_outpoints.len());
+        let mut psbt_ins = Vec::with_capacity(coins_outpoints.len());
         let mut spent_txs = HashMap::with_capacity(coins_outpoints.len());
         let coins = db_conn.coins_by_outpoints(coins_outpoints);
         for op in coins_outpoints {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -81,7 +81,7 @@ pub trait DatabaseConnection {
     ) -> Option<(bip32::ChildNumber, bool)>;
 
     /// Get all our coins, past or present, spent or not.
-    fn coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
+    fn coins(&mut self, coin_type: CoinType) -> HashMap<bitcoin::OutPoint, Coin>;
 
     /// List coins that are being spent and whose spending transaction is still unconfirmed.
     fn list_spending_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
@@ -178,8 +178,8 @@ impl DatabaseConnection for SqliteConn {
         self.complete_wallet_rescan()
     }
 
-    fn coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
-        self.coins()
+    fn coins(&mut self, coin_type: CoinType) -> HashMap<bitcoin::OutPoint, Coin> {
+        self.coins(coin_type)
             .into_iter()
             .map(|db_coin| (db_coin.outpoint, db_coin.into()))
             .collect()
@@ -315,4 +315,11 @@ impl Coin {
     pub fn is_spent(&self) -> bool {
         self.spend_txid.is_some()
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CoinType {
+    All,
+    Unspent,
+    Spent,
 }

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -480,6 +480,17 @@ impl MultipathDescriptor {
             .expect("Cannot fail for P2WSH")
     }
 
+    /// Get the maximum size in vbytes (rounded up) of a satisfaction for this descriptor.
+    pub fn max_sat_vbytes(&self) -> usize {
+        self.multi_desc
+            .max_satisfaction_weight()
+            .expect("Cannot fail for P2WSH")
+            .checked_add(WITNESS_FACTOR - 1)
+            .unwrap()
+            .checked_div(WITNESS_FACTOR)
+            .unwrap()
+    }
+
     /// Get the maximum size in virtual bytes of the whole input in a transaction spending
     /// a coin with this Script.
     pub fn spender_input_size(&self) -> usize {
@@ -581,13 +592,6 @@ impl DerivedInheritanceDescriptor {
             .map(|k| (k.key.inner, (k.origin.0, k.origin.1)))
             .collect()
     }
-
-    /// Get the maximum size in WU of a satisfaction for this descriptor.
-    pub fn max_sat_weight(&self) -> usize {
-        self.0
-            .max_satisfaction_weight()
-            .expect("Cannot fail for P2WSH")
-    }
 }
 
 #[cfg(test)]
@@ -657,7 +661,6 @@ mod tests {
         der_desc.script_pubkey();
         der_desc.witness_script();
         assert!(!der_desc.bip32_derivations().is_empty());
-        assert!(!der_desc.max_sat_weight() > 0);
     }
 
     #[test]
@@ -674,17 +677,8 @@ mod tests {
 
     #[test]
     fn inheritance_descriptor_sat_size() {
-        let secp = secp256k1::Secp256k1::verification_only();
         let desc = MultipathDescriptor::from_str("wsh(or_d(pk([92162c45]tpubD6NzVbkrYhZ4WzTf9SsD6h7AH7oQEippXK2KP8qvhMMqFoNeN5YFVi7vRyeRSDGtgd2bPyMxUNmHui8t5yCgszxPPxMafu1VVzDpg9aruYW/<0;1>/*),and_v(v:pkh(tpubD6NzVbkrYhZ4Wdgu2yfdmrce5g4fiH1ZLmKhewsnNKupbi4sxjH1ZVAorkBLWSkhsjhg8kiq8C4BrBjMy3SjAKDyDdbuvUa1ToAHbiR98js/<0;1>/*),older(2))))#uact7s3g").unwrap();
-        let receive_desc = desc.receive_descriptor();
-        let change_desc = desc.change_descriptor();
-
-        // Derived or not the expected maximum satisfaction size should be the same for
-        // the change and receive descriptor.
-        assert_eq!(
-            receive_desc.derive(999.into(), &secp).max_sat_weight(),
-            change_desc.derive(999.into(), &secp).max_sat_weight()
-        );
+        assert_eq!(desc.max_sat_vbytes(), (1 + 69 + 1 + 34 + 73 + 3) / 4); // See the stack details below.
 
         // Maximum input size is (txid + vout + scriptsig + nSequence + max_sat).
         // Where max_sat is:

--- a/src/jsonrpc/api.rs
+++ b/src/jsonrpc/api.rs
@@ -187,7 +187,23 @@ pub fn handle_request(control: &DaemonControl, req: Request) -> Result<Response,
         "getinfo" => serde_json::json!(&control.get_info()),
         "getnewaddress" => serde_json::json!(&control.get_new_address()),
         "listcoins" => serde_json::json!(&control.list_coins()),
+        "listconfirmed" => {
+            let params = req.params.ok_or_else(|| {
+                Error::invalid_params(
+                    "The 'listconfirmed' command requires 3 parameters: 'start', 'end' and 'limit'",
+                )
+            })?;
+            list_confirmed(control, params)?
+        }
         "listspendtxs" => serde_json::json!(&control.list_spend()),
+        "listtransactions" => {
+            let params = req.params.ok_or_else(|| {
+                Error::invalid_params(
+                    "The 'listtransactions' command requires 1 parameter: 'txids'",
+                )
+            })?;
+            list_transactions(control, params)?
+        }
         "startrescan" => {
             let params = req
                 .params
@@ -200,22 +216,6 @@ pub fn handle_request(control: &DaemonControl, req: Request) -> Result<Response,
                 .params
                 .ok_or_else(|| Error::invalid_params("Missing 'psbt' parameter."))?;
             update_spend(control, params)?
-        }
-        "listconfirmed" => {
-            let params = req.params.ok_or_else(|| {
-                Error::invalid_params(
-                    "The 'listconfirmed' command requires 3 parameters: 'start', 'end' and 'limit'",
-                )
-            })?;
-            list_confirmed(control, params)?
-        }
-        "listtransactions" => {
-            let params = req.params.ok_or_else(|| {
-                Error::invalid_params(
-                    "The 'listtransactions' command requires 1 parameter: 'txids'",
-                )
-            })?;
-            list_transactions(control, params)?
         }
         _ => {
             return Err(Error::method_not_found());

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -161,7 +161,8 @@ impl From<commands::CommandError> for Error {
             | commands::CommandError::UnknownSpend(..)
             | commands::CommandError::SpendFinalization(..)
             | commands::CommandError::InsaneRescanTimestamp(..)
-            | commands::CommandError::AlreadyRescanning => {
+            | commands::CommandError::AlreadyRescanning
+            | commands::CommandError::RecoveryNotAvailable => {
                 Error::new(ErrorCode::InvalidParams, e.to_string())
             }
             commands::CommandError::FetchingTransaction(..)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -119,15 +119,17 @@ def lianad(bitcoind, directory):
     bitcoind_cookie = os.path.join(bitcoind.bitcoin_dir, "regtest", ".cookie")
 
     owner_hd = BIP32.from_seed(os.urandom(32), network="test")
-    owner_xpub = owner_hd.get_xpub()
+    recovery_hd = BIP32.from_seed(os.urandom(32), network="test")
+    owner_xpub, recovery_xpub = owner_hd.get_xpub(), recovery_hd.get_xpub()
     csv_value = 10
     main_desc = Descriptor.from_str(
-        f"wsh(or_d(pk({owner_xpub}/<0;1>/*),and_v(v:pkh(tpubD9vQiBdDxYzU4cVFtApWj4devZrvcfWaPXX1zHdDc7GPfUsDKqGnbhraccfm7BAXgRgUbVQUV2v2o4NitjGEk7hpbuP85kvBrD4ahFDtNBJ/<0;1>/*),older({csv_value}))))"
+        f"wsh(or_d(pk({owner_xpub}/<0;1>/*),and_v(v:pkh({recovery_xpub}/<0;1>/*),older({csv_value}))))"
     )
 
     lianad = Lianad(
         datadir,
         owner_hd,
+        recovery_hd,
         main_desc,
         bitcoind.rpcport,
         bitcoind_cookie,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -120,7 +120,10 @@ def lianad(bitcoind, directory):
 
     owner_hd = BIP32.from_seed(os.urandom(32), network="test")
     owner_xpub = owner_hd.get_xpub()
-    main_desc = Descriptor.from_str(f"wsh(or_d(pk({owner_xpub}/<0;1>/*),and_v(v:pkh(tpubD9vQiBdDxYzU4cVFtApWj4devZrvcfWaPXX1zHdDc7GPfUsDKqGnbhraccfm7BAXgRgUbVQUV2v2o4NitjGEk7hpbuP85kvBrD4ahFDtNBJ/<0;1>/*),older(65000))))")
+    csv_value = 10
+    main_desc = Descriptor.from_str(
+        f"wsh(or_d(pk({owner_xpub}/<0;1>/*),and_v(v:pkh(tpubD9vQiBdDxYzU4cVFtApWj4devZrvcfWaPXX1zHdDc7GPfUsDKqGnbhraccfm7BAXgRgUbVQUV2v2o4NitjGEk7hpbuP85kvBrD4ahFDtNBJ/<0;1>/*),older({csv_value}))))"
+    )
 
     lianad = Lianad(
         datadir,

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -75,6 +75,14 @@ def spend_coins(lianad, bitcoind, coins):
     return tx
 
 
+def sign_and_broadcast(lianad, bitcoind, psbt, recovery=False):
+    """Sign a PSBT, finalize it, extract the transaction and broadcast it."""
+    signed_psbt = lianad.sign_psbt(psbt, recovery)
+    finalized_psbt = lianad.finalize_psbt(signed_psbt)
+    tx = finalized_psbt.tx.serialize_with_witness().hex()
+    return bitcoind.rpc.sendrawtransaction(tx)
+
+
 class RpcError(ValueError):
     def __init__(self, method: str, params: dict, error: str):
         super(ValueError, self).__init__(

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -130,7 +130,7 @@ def test_create_spend(lianad, bitcoind):
         )
 
     # We can sign it and broadcast it.
-    sign_and_broadcast(PSBT.from_base64(res["psbt"]))
+    sign_and_broadcast(lianad, bitcoind, PSBT.from_base64(res["psbt"]))
 
 
 def test_list_spend(lianad, bitcoind):
@@ -537,3 +537,51 @@ def test_listtransactions(lianad, bitcoind):
     assert len(txs) == 3
     bit_txids = set(bitcoind.rpc.decoderawtransaction(tx["tx"])["txid"] for tx in txs)
     assert bit_txids == txids
+
+
+def test_create_recovery(lianad, bitcoind):
+    """Test the sweep of coins that are available through the timelocked path."""
+    # Start by getting a few coins
+    destinations = {
+        lianad.rpc.getnewaddress()["address"]: 0.1,
+        lianad.rpc.getnewaddress()["address"]: 0.2,
+        lianad.rpc.getnewaddress()["address"]: 0.3,
+    }
+    txid = bitcoind.rpc.sendmany("", destinations)
+    bitcoind.generate_block(1, wait_for_mempool=txid)
+    wait_for(
+        lambda: lianad.rpc.getinfo()["block_height"] == bitcoind.rpc.getblockcount()
+    )
+
+    # There's nothing to sweep
+    with pytest.raises(
+        RpcError,
+        match="No coin currently available through the timelocked recovery path",
+    ):
+        lianad.rpc.createrecovery(bitcoind.rpc.getnewaddress(), 2)
+
+    # Receive another coin, it will be one block after the others
+    txid = bitcoind.rpc.sendtoaddress(lianad.rpc.getnewaddress()["address"], 0.4)
+
+    # Make the timelock of the 3 first coins mature (we use a csv of 10 in the fixture)
+    bitcoind.generate_block(9, wait_for_mempool=txid)
+
+    # Now we can create a recovery tx that sweeps the first 3 coins.
+    res = lianad.rpc.createrecovery(bitcoind.rpc.getnewaddress(), 18)
+    reco_psbt = PSBT.from_base64(res["psbt"])
+    assert len(reco_psbt.tx.vin) == 3, "The last coin's timelock hasn't matured yet"
+    assert len(reco_psbt.tx.vout) == 1
+    assert int(0.5999 * COIN) < int(reco_psbt.tx.vout[0].nValue) < int(0.6 * COIN)
+    txid = sign_and_broadcast(lianad, bitcoind, reco_psbt, recovery=True)
+
+    # And by mining one more block we'll be able to sweep the last coin.
+    bitcoind.generate_block(1, wait_for_mempool=txid)
+    wait_for(
+        lambda: lianad.rpc.getinfo()["block_height"] == bitcoind.rpc.getblockcount()
+    )
+    res = lianad.rpc.createrecovery(bitcoind.rpc.getnewaddress(), 1)
+    reco_psbt = PSBT.from_base64(res["psbt"])
+    assert len(reco_psbt.tx.vin) == 1
+    assert len(reco_psbt.tx.vout) == 1
+    assert int(0.39999 * COIN) < int(reco_psbt.tx.vout[0].nValue) < int(0.4 * COIN)
+    sign_and_broadcast(lianad, bitcoind, reco_psbt, recovery=True)

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -8,7 +8,14 @@ from test_framework.serializations import (
     PSBT_IN_PARTIAL_SIG,
     PSBT_IN_NON_WITNESS_UTXO,
 )
-from test_framework.utils import wait_for, COIN, RpcError, get_txid, spend_coins
+from test_framework.utils import (
+    wait_for,
+    COIN,
+    RpcError,
+    get_txid,
+    spend_coins,
+    sign_and_broadcast,
+)
 
 
 def test_getinfo(lianad):
@@ -123,10 +130,7 @@ def test_create_spend(lianad, bitcoind):
         )
 
     # We can sign it and broadcast it.
-    signed_psbt = lianad.sign_psbt(PSBT.from_base64(res["psbt"]))
-    finalized_psbt = lianad.finalize_psbt(signed_psbt)
-    tx = finalized_psbt.tx.serialize_with_witness().hex()
-    bitcoind.rpc.sendrawtransaction(tx)
+    sign_and_broadcast(PSBT.from_base64(res["psbt"]))
 
 
 def test_list_spend(lianad, bitcoind):


### PR DESCRIPTION
A new command that provides a simple way for a user to sweep all the coins whose timelocked recovery path is available.

The first part of #180. Note this also contains a number of drive-by fixes that i noticed while coding this up.