### PR TITLE
fix gui: wrong event selection on home panel

### DIFF
--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -75,10 +75,15 @@ impl Home {
 impl State for Home {
     fn view<'a>(&'a self, cache: &'a Cache) -> Element<'a, view::Message> {
         if let Some(i) = self.selected_event {
+            let event = if i < self.pending_events.len() {
+                &self.pending_events[i]
+            } else {
+                &self.events[i - self.pending_events.len()]
+            };
             return view::modal(
                 false,
                 self.warning.as_ref(),
-                view::home::event_view(cache, &self.events[i]),
+                view::home::event_view(cache, event),
                 None::<Element<view::Message>>,
             );
         }

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -69,7 +69,7 @@ pub fn home_view<'a>(
                         .iter()
                         .enumerate()
                         .fold(Column::new().spacing(10), |col, (i, event)| {
-                            col.push(event_list_view(i, event))
+                            col.push(event_list_view(i + pending_events.len(), event))
                         }),
                 )
                 .push_maybe(


### PR DESCRIPTION
Because pending events are in a different list
that confirmed event. The wrong list item was
selected when user tried to click on a pending
event.