### PR TITLE
Add broadcasttx command

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -14,6 +14,7 @@ Commands must be sent as valid JSONRPC 2.0 requests, ending with a `\n`.
 | [`listspendtxs`](#listspendtxs)                             | List all stored Spend transactions                            |
 | [`delspendtx`](#delspendtx)                                 | Delete a stored Spend transaction                             |
 | [`broadcastspend`](#broadcastspend)                         | Finalize a stored Spend PSBT, and broadcast it                |
+| [`broadcasttx`](#broadcasttx)                               | Finalize a given PSBT, and broadcast it                       |
 | [`startrescan`](#startrescan)                               | Start rescanning the block chain from a given date            |
 | [`listconfirmed`](#listconfirmed)                           | List of confirmed transactions of incoming and outgoing funds |
 | [`listtransactions`](#listtransactions)                     | List of transactions with the given txids                     |
@@ -196,6 +197,21 @@ This command does not return anything for now.
 | Field    | Type   | Description                                            |
 | -------- | ------ | ------------------------------------------------------ |
 | `txid`   | string | Hex encoded txid of the Spend transaction to broadcast |
+
+#### Response
+
+This command does not return anything for now.
+
+| Field          | Type      | Description                                          |
+| -------------- | --------- | ---------------------------------------------------- |
+
+### `broadcasttx`
+
+#### Request
+
+| Field    | Type   | Description                                            |
+| -------- | ------ | ------------------------------------------------------ |
+| `psbt`   | string | Base64-encoded PSBT of a Spend transaction.            |
 
 #### Response
 

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -159,7 +159,7 @@ impl From<commands::CommandError> for Error {
             | commands::CommandError::InvalidOutputValue(..)
             | commands::CommandError::InsufficientFunds(..)
             | commands::CommandError::UnknownSpend(..)
-            | commands::CommandError::SpendFinalization(..)
+            | commands::CommandError::TxFinalization(..)
             | commands::CommandError::InsaneRescanTimestamp(..)
             | commands::CommandError::AlreadyRescanning => {
                 Error::new(ErrorCode::InvalidParams, e.to_string())


### PR DESCRIPTION
`createrecovery` creates a psbt that needs
to be broadcasted after being signed.
`broadcastspend` cannot be used because the
recovery transaction is not store as spend tx.