### PR TITLE
fix spend change detection

### DIFF
--- a/gui/src/app/state/spend/step.rs
+++ b/gui/src/app/state/spend/step.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 use iced::{Command, Element};
 use liana::{
     config::Config as DaemonConfig,
-    miniscript::bitcoin::{
-        self, util::psbt::Psbt, Address, Amount, Denomination, OutPoint, Script,
-    },
+    miniscript::bitcoin::{self, util::psbt::Psbt, Address, Amount, Denomination, OutPoint},
 };
 
 use crate::{
@@ -416,26 +414,9 @@ impl SaveSpend {
 
 impl Step for SaveSpend {
     fn load(&mut self, draft: &TransactionDraft) {
-        let outputs_script_pubkeys: Vec<Script> = draft
-            .outputs
-            .keys()
-            .map(|addr| addr.script_pubkey())
-            .collect();
-        let index = if let Some(psbt) = &draft.generated {
-            psbt.unsigned_tx
-                .output
-                .iter()
-                .position(|output| !outputs_script_pubkeys.contains(&output.script_pubkey))
-        } else {
-            None
-        };
         self.spend = Some(detail::SpendTxState::new(
             self.config.clone(),
-            SpendTx::new(
-                draft.generated.clone().unwrap(),
-                index,
-                draft.inputs.clone(),
-            ),
+            SpendTx::new(draft.generated.clone().unwrap(), draft.inputs.clone()),
             false,
         ));
     }

--- a/gui/src/app/view/spend/detail.rs
+++ b/gui/src/app/view/spend/detail.rs
@@ -44,7 +44,7 @@ pub fn spend_view<'a, T: Into<Element<'a, Message>>>(
                 &tx.coins,
                 &tx.psbt.unsigned_tx,
                 network,
-                tx.change_index.map(|i| vec![i]),
+                Some(tx.change_indexes.clone()),
                 None,
             )),
     )

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -88,7 +88,7 @@ pub trait Daemon: Debug {
                     })
                     .copied()
                     .collect();
-                model::SpendTx::new(tx.psbt, tx.change_index.map(|i| i as usize), coins)
+                model::SpendTx::new(tx.psbt, coins)
             })
             .collect())
     }


### PR DESCRIPTION
Use the presence of bip32_derivation
in the spend outputs to detect the
change outputs.