### PR TITLE
Remove change_index from listspendtxs response

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -174,7 +174,6 @@ This command does not take any parameter for now.
 | Field          | Type              | Description                                                             |
 | -------------- | ----------------- | ----------------------------------------------------------------------- |
 | `psbt`         | string            | Base64-encoded PSBT of the Spend transaction.                           |
-| `change_index` | int or null       | Index of the change output in the transaction outputs, if there is one. |
 
 
 ### `delspendtx`

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,9 +10,7 @@ use crate::{
     descriptors, DaemonControl, VERSION,
 };
 
-use utils::{
-    change_index, deser_amount_from_sats, deser_base64, deser_hex, ser_amount, ser_base64, ser_hex,
-};
+use utils::{deser_amount_from_sats, deser_base64, deser_hex, ser_amount, ser_base64, ser_hex};
 
 use std::{
     collections::{hash_map, BTreeMap, HashMap},
@@ -507,11 +505,7 @@ impl DaemonControl {
         let spend_txs = db_conn
             .list_spend()
             .into_iter()
-            .map(|psbt| {
-                let change_index =
-                    change_index(&psbt, &mut db_conn).map(|i| i.try_into().expect("insane usize"));
-                ListSpendEntry { psbt, change_index }
-            })
+            .map(|psbt| ListSpendEntry { psbt })
             .collect();
         ListSpendResult { spend_txs }
     }
@@ -786,7 +780,6 @@ pub struct CreateSpendResult {
 pub struct ListSpendEntry {
     #[serde(serialize_with = "ser_base64", deserialize_with = "deser_base64")]
     pub psbt: Psbt,
-    pub change_index: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -168,9 +168,7 @@ def test_list_spend(lianad, bitcoind):
     list_res = lianad.rpc.listspendtxs()["spend_txs"]
     assert len(list_res) == 2
     first_psbt = next(entry for entry in list_res if entry["psbt"] == res["psbt"])
-    assert first_psbt["change_index"] == 1
     second_psbt = next(entry for entry in list_res if entry["psbt"] == res_b["psbt"])
-    assert second_psbt["change_index"] is None
 
     # If we delete the first one, we'll get only the second one.
     first_psbt = PSBT.from_base64(res["psbt"])


### PR DESCRIPTION
Multiple change indexes may be present in a spend
draft transaction and can be detected instead
in the response psbt with the bip32_derivation
outputs fields.